### PR TITLE
Assert config table structure

### DIFF
--- a/baton.lua
+++ b/baton.lua
@@ -208,6 +208,8 @@ function Player:getActiveDevice()
 end
 
 function baton.new(config)
+  assert(config.controls, 'The config table should provide a controls table.')
+  assert(config.pairs,    'The config table should provide a pairs table.'   )
   local player = setmetatable({
     _controls = {},
     _pairs = {},


### PR DESCRIPTION
I'd either go with this or with something like `controls.pairs = controls.pairs or {}` to automatically create an empty table.

Better than getting a cryptic error message like:
```
[ERROR] lib/Baton.lua:230: bad argument #1 to 'pairs' (table expected, got nil)
stack traceback:
```

Also: The rewrite seems to be much nicer for the garbage collector 👍