### PR TITLE
Implemented the ability for the user to add new input types

### DIFF
--- a/baton.lua
+++ b/baton.lua
@@ -58,15 +58,16 @@ end
 	return a number from 0 to 1.
 
 	source functions are split into keyboard/mouse functions
-	and joystick/gamepad functions. baton treats these two
-	categories slightly differently.
+	and joystick/gamepad functions and custom functions. baton
+	treats these three categories slightly differently.
 ]]
 
-local sourceFunction = {keyboardMouse = {}, joystick = {}}
+local sourceFunction = {keyboardMouse = {}, joystick = {}, custom = {}}
 
 -- checks whether a keyboard key is down or not
 function sourceFunction.keyboardMouse.key(key)
 	return love.keyboard.isDown(key) and 1 or 0
+	--return keyPress == key and 1 or 0
 end
 
 -- checks whether a keyboard key is down or not,
@@ -231,6 +232,11 @@ function Player:_getControlRawValue(control)
 			if rawValue >= 1 then
 				return 1
 			end
+		elseif sourceFunction.custom[type] then
+		  rawValue = rawValue + sourceFunction.custom[type](value)
+		  if rawValue >= 1 then
+				return 1
+			end
 		end
 	end
 	return rawValue
@@ -246,8 +252,8 @@ function Player:_updateControls()
 		control.value = control.rawValue >= self.config.deadzone and control.rawValue or 0
 		control.downPrevious = control.down
 		control.down = control.value > 0
-		control.pressed = control.down and not control.downPrevious
-		control.released = control.downPrevious and not control.down
+		control.pressed = control.down and not control.downPrevious 
+		control.released = control.downPrevious and not control.down 
 	end
 end
 
@@ -370,5 +376,19 @@ function baton.new(config)
 	player:_init(config)
 	return player
 end
+
+--[[
+  this function allows the additon of custom input types.
+  it allows the ability to use diffent input pereferies.
+  all the new pereferies are stored whithin the custom category.
+]]
+function baton.newInputType(name, func)
+  sourceFunction.custom[name] = func
+end
+
+-- those parse functions are made public so they can be used
+-- for custom input types
+baton.parseAxis = parseAxis
+baton.parseHat  = parseHat
 
 return baton

--- a/baton.lua
+++ b/baton.lua
@@ -66,8 +66,7 @@ local sourceFunction = {keyboardMouse = {}, joystick = {}, custom = {}}
 
 -- checks whether a keyboard key is down or not
 function sourceFunction.keyboardMouse.key(key)
-	return love.keyboard.isDown(key) and 1 or 0
-	--return keyPress == key and 1 or 0
+	return love.keyboard.isDown(key) and 1 or 0	
 end
 
 -- checks whether a keyboard key is down or not,

--- a/readme.md
+++ b/readme.md
@@ -131,28 +131,55 @@ released = player:released(control)
 These functions are most applicable for controls that act as buttons, such as a shoot button. That being said, they can be used for any control, which is useful if you want to, for example, use a movement control as a discrete button press to operate a menu.
 
 #### Updating the configuration
-The `controls` table, `pairs` table, `joystick`, `deadzone`, and `squareDeadzone` can all be accessed via `player.config`. Any of the values can be changed, and the player's behavior will be updated automatically. Note, however, that new controls and pairs cannot be added after the player is created, and controls and pairs should not be removed entirely (if you want to disable a control, you can set it to an empty table, removing all of its sources).
+The `controls` table, `pairs` table, `joystick`, `deadzone`, and `squareDeadzone` can all be accessed via `player.config`. Any of the values can be changed, and the player's behavior will be updated automatically. Note, however, that new controls and pairs cannot be added after the player is created, and controls and pairs should not be removed entirely (if you want to disable a control, you can set it to an empty table, removig all of its sources).
+
 
 #### Getting the active input device
 At any time, only the keyboard/mouse sources or the joystick sources for a player will be active. A device will be considered active if any of the sources for that device exceed the deadzone. The keyboard and mouse will always take precedence over the joystick.
 
 You can call `player:getActiveDevice()` to see which input device is currently active. It will return either `'kbm'` (keyboard/mouse) or `'joy'` (joystick) (or `'none'` if no sources have been used yet). This is useful if you need to change what you display on screen based on the controls the player is using (such as instructions).
 
+Note: custom input types are not tracked at all.
+
 ### Adding custom input types
 you can add your own input types using:
 ```lua
-baton.newInputType(name, input)
+baton.newInputType(name, sourceFunction)
 ```
 
-- `name` is the name of the new type.
-
-- `input` is a function in this form:
+- `name` is the name of the new type. it is used when defining controls.
+- `sourceFunction` is the function that determines the output value. It defined in this form:
+  ```lua
+  value = function(source)
+  ```
+  - `value` is the output returned by the function it must be a number between 0 and 1.
+  - `source` is the name on the right of the collumn when defining the controls.
+#### Example:
 ```lua
-input = function(value)
-```
-it should always return a number between 0 and 1.
+baton.newInputType(ui, function(source)
+  return uiIsDown(source) and 1 or 0
+end)
 
-  - `value` is the name of the source.
+local baton.new {
+  controls = {
+    back = {'key:left', 'ui:back'},
+    next = {'key:right', 'ui:next'},
+    confirm = {'key:enter', 'ui:confirm'},
+  }
+}
+```
+In this example I made an input type for the ui elements. and then made a player to handle the inputs from both the ui and the shortcuts.
+### Parsing functions
+Parsing functions are functions that help you get more information from the name of the control. There are two of them:
+```lua
+baton.parseAxis(source)
+baton.parseHat(source)
+```
+- `baton.parseAxis` splits a source definition into type and value
+  - example: `'button:a' -> 'button', 'a'`
+
+- `baton.parseHat` splits an axis value into axis and direction
+  - example: `'leftx-' -> 'leftx', '-'`
 
 ## Contributing
 Issues and pull requests are always welcome. To run the test, run `love .` in the baton folder.

--- a/readme.md
+++ b/readme.md
@@ -138,5 +138,21 @@ At any time, only the keyboard/mouse sources or the joystick sources for a playe
 
 You can call `player:getActiveDevice()` to see which input device is currently active. It will return either `'kbm'` (keyboard/mouse) or `'joy'` (joystick) (or `'none'` if no sources have been used yet). This is useful if you need to change what you display on screen based on the controls the player is using (such as instructions).
 
+### Adding custom input types
+you can add your own input types using:
+```lua
+baton.newInputType(name, input)
+```
+
+- `name` is the name of the new type.
+
+- `input` is a function in this form:
+```lua
+input = function(value)
+```
+it should always return a number between 0 and 1.
+
+  - `value` is the name of the source.
+
 ## Contributing
 Issues and pull requests are always welcome. To run the test, run `love .` in the baton folder.


### PR DESCRIPTION
As the title sais now you can make it so any function that can output a number between 0 and 1 to be it's own input type and can be used along side the other ones. For more details on how to use it check the bottom of the updated readme.md

This feature is useful for UI and especially for mobile games since it allows you to easily bind the touch controls using baton.